### PR TITLE
Add I18n support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "trynano-app",
-  "version": "3.0.1",
+  "version": "3.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "trynano-app",
-      "version": "3.0.1",
+      "version": "3.1.0",
       "dependencies": {
         "@nanobox/nano-client": "latest",
         "@soerenmartius/vue3-clipboard": "^0.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@soerenmartius/vue3-clipboard": "^0.1.1",
         "axios": "^0.21.1",
         "core-js": "^3.6.5",
-        "element-plus": "latest",
+        "element-plus": "^1.0.2-beta.33",
         "emailjs-com": "^2.6.4",
         "hover.css": "^2.3.2",
         "mitt": "^2.1.0",
@@ -21,6 +21,7 @@
         "vue": "^3.0.7",
         "vue-axios": "^3.2.4",
         "vue-element-loading": "^3.0.1",
+        "vue-i18n": "^9.0.0",
         "vue-recaptcha-v3": "^2.0.0",
         "vue3-mq": "^2.3.1"
       },
@@ -1356,6 +1357,70 @@
         "webpack": "^4.0.0"
       }
     },
+    "node_modules/@intlify/core-base": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@intlify/core-base/-/core-base-9.0.0.tgz",
+      "integrity": "sha512-dxqakT94EV2bFshG3LENQUPWX9yJFCga1BOwJ6mz7J8LnAYVB9Kxw7NRyE2ybN31USW2IUTQH6WWR1yDbCiefQ==",
+      "dependencies": {
+        "@intlify/message-compiler": "9.0.0",
+        "@intlify/message-resolver": "9.0.0",
+        "@intlify/runtime": "9.0.0",
+        "@intlify/shared": "9.0.0"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@intlify/message-compiler": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@intlify/message-compiler/-/message-compiler-9.0.0.tgz",
+      "integrity": "sha512-3oiLj+8z6koRYJwknazjilBsrqnJEAJywr/t39MYVy2yPmwOI1+NDfdDwM9U3ioA2RvsQEUICqW8gmjq1YIElw==",
+      "dependencies": {
+        "@intlify/message-resolver": "9.0.0",
+        "@intlify/shared": "9.0.0",
+        "source-map": "0.6.1"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@intlify/message-compiler/node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/@intlify/message-resolver": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@intlify/message-resolver/-/message-resolver-9.0.0.tgz",
+      "integrity": "sha512-LVK4cwu1l33yvBy0UQkEdXm6pZUcbbiparobruJXz+U8jRTmYHBprN59j59YKXEKcV43cHfzNveaQIm84bgxvQ==",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@intlify/runtime": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@intlify/runtime/-/runtime-9.0.0.tgz",
+      "integrity": "sha512-UqCKduZezb5/qA+XPRfHVvXoLmhnQ8iKMyCh0Lg3ZwjW2vOMep/AgZU3T9cgESe67r4buPYHs7nOBSHbTdjNxg==",
+      "dependencies": {
+        "@intlify/message-compiler": "9.0.0",
+        "@intlify/message-resolver": "9.0.0",
+        "@intlify/shared": "9.0.0"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@intlify/shared": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@intlify/shared/-/shared-9.0.0.tgz",
+      "integrity": "sha512-0r4v7dnY8g/Jfx2swUWy2GyfH/WvIpWvkU4OIupvxDTWiE8RhcpbOCVvqpVh/xGi0proHQ/r2Dhc0QSItUsfDQ==",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/@mrmlnc/readdir-enhanced": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz",
@@ -2354,6 +2419,11 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
       "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
       "dev": true
+    },
+    "node_modules/@vue/devtools-api": {
+      "version": "6.0.0-beta.7",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-6.0.0-beta.7.tgz",
+      "integrity": "sha512-mIfqX8ZF6s2ulelIzfxGk9sFoigpoeK/2/DlWrtBGWfvwaK3kR1P2bxNkZ0LbJeuKHfcRP6hGZtGist7nxUN9A=="
     },
     "node_modules/@vue/eslint-config-airbnb": {
       "version": "5.3.0",
@@ -14577,6 +14647,22 @@
       "integrity": "sha512-BXq3jwIagosjgNVae6tkHzzIk6a8MHFtzAdwhnV5VlvPTFxDCvIttgSiHWjdGoTJvXtmRu5HacExfdarRcFhog==",
       "dev": true
     },
+    "node_modules/vue-i18n": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/vue-i18n/-/vue-i18n-9.0.0.tgz",
+      "integrity": "sha512-iks0eJDv/4cK/7tl/ooMUroNVVIGOK4kKS1PIHmPQk7QjT/sDfFM84vjPKgpARbw0GjJsOiADL43jufNfs9e9A==",
+      "dependencies": {
+        "@intlify/core-base": "9.0.0",
+        "@intlify/shared": "9.0.0",
+        "@vue/devtools-api": "^6.0.0-beta.5"
+      },
+      "engines": {
+        "node": ">= 10"
+      },
+      "peerDependencies": {
+        "vue": "^3.0.0"
+      }
+    },
     "node_modules/vue-loader": {
       "version": "15.9.6",
       "resolved": "https://registry.npmjs.org/vue-loader/-/vue-loader-15.9.6.tgz",
@@ -17246,6 +17332,54 @@
         "postcss": "^7.0.0"
       }
     },
+    "@intlify/core-base": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@intlify/core-base/-/core-base-9.0.0.tgz",
+      "integrity": "sha512-dxqakT94EV2bFshG3LENQUPWX9yJFCga1BOwJ6mz7J8LnAYVB9Kxw7NRyE2ybN31USW2IUTQH6WWR1yDbCiefQ==",
+      "requires": {
+        "@intlify/message-compiler": "9.0.0",
+        "@intlify/message-resolver": "9.0.0",
+        "@intlify/runtime": "9.0.0",
+        "@intlify/shared": "9.0.0"
+      }
+    },
+    "@intlify/message-compiler": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@intlify/message-compiler/-/message-compiler-9.0.0.tgz",
+      "integrity": "sha512-3oiLj+8z6koRYJwknazjilBsrqnJEAJywr/t39MYVy2yPmwOI1+NDfdDwM9U3ioA2RvsQEUICqW8gmjq1YIElw==",
+      "requires": {
+        "@intlify/message-resolver": "9.0.0",
+        "@intlify/shared": "9.0.0",
+        "source-map": "0.6.1"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+        }
+      }
+    },
+    "@intlify/message-resolver": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@intlify/message-resolver/-/message-resolver-9.0.0.tgz",
+      "integrity": "sha512-LVK4cwu1l33yvBy0UQkEdXm6pZUcbbiparobruJXz+U8jRTmYHBprN59j59YKXEKcV43cHfzNveaQIm84bgxvQ=="
+    },
+    "@intlify/runtime": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@intlify/runtime/-/runtime-9.0.0.tgz",
+      "integrity": "sha512-UqCKduZezb5/qA+XPRfHVvXoLmhnQ8iKMyCh0Lg3ZwjW2vOMep/AgZU3T9cgESe67r4buPYHs7nOBSHbTdjNxg==",
+      "requires": {
+        "@intlify/message-compiler": "9.0.0",
+        "@intlify/message-resolver": "9.0.0",
+        "@intlify/shared": "9.0.0"
+      }
+    },
+    "@intlify/shared": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/@intlify/shared/-/shared-9.0.0.tgz",
+      "integrity": "sha512-0r4v7dnY8g/Jfx2swUWy2GyfH/WvIpWvkU4OIupvxDTWiE8RhcpbOCVvqpVh/xGi0proHQ/r2Dhc0QSItUsfDQ=="
+    },
     "@mrmlnc/readdir-enhanced": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz",
@@ -18074,6 +18208,11 @@
           "dev": true
         }
       }
+    },
+    "@vue/devtools-api": {
+      "version": "6.0.0-beta.7",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-6.0.0-beta.7.tgz",
+      "integrity": "sha512-mIfqX8ZF6s2ulelIzfxGk9sFoigpoeK/2/DlWrtBGWfvwaK3kR1P2bxNkZ0LbJeuKHfcRP6hGZtGist7nxUN9A=="
     },
     "@vue/eslint-config-airbnb": {
       "version": "5.3.0",
@@ -28041,6 +28180,16 @@
       "resolved": "https://registry.npmjs.org/vue-hot-reload-api/-/vue-hot-reload-api-2.3.4.tgz",
       "integrity": "sha512-BXq3jwIagosjgNVae6tkHzzIk6a8MHFtzAdwhnV5VlvPTFxDCvIttgSiHWjdGoTJvXtmRu5HacExfdarRcFhog==",
       "dev": true
+    },
+    "vue-i18n": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/vue-i18n/-/vue-i18n-9.0.0.tgz",
+      "integrity": "sha512-iks0eJDv/4cK/7tl/ooMUroNVVIGOK4kKS1PIHmPQk7QjT/sDfFM84vjPKgpARbw0GjJsOiADL43jufNfs9e9A==",
+      "requires": {
+        "@intlify/core-base": "9.0.0",
+        "@intlify/shared": "9.0.0",
+        "@vue/devtools-api": "^6.0.0-beta.5"
+      }
     },
     "vue-loader": {
       "version": "15.9.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "trynano-app",
-  "version": "2.1.3",
+  "version": "3.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "trynano-app",
-      "version": "2.1.3",
+      "version": "3.0.0",
       "dependencies": {
         "@nanobox/nano-client": "latest",
         "@soerenmartius/vue3-clipboard": "^0.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "trynano-app",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "trynano-app",
-      "version": "3.0.0",
+      "version": "3.0.1",
       "dependencies": {
         "@nanobox/nano-client": "latest",
         "@soerenmartius/vue3-clipboard": "^0.1.1",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "vue": "^3.0.7",
     "vue-axios": "^3.2.4",
     "vue-element-loading": "^3.0.1",
+    "vue-i18n": "^9.0.0",
     "vue-recaptcha-v3": "^2.0.0",
     "vue3-mq": "^2.3.1"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trynano-app",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "private": true,
   "scripts": {
     "serve": "vue-cli-service serve",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trynano-app",
-  "version": "3.0.1",
+  "version": "3.1.0",
   "private": true,
   "scripts": {
     "serve": "vue-cli-service serve",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trynano-app",
-  "version": "2.1.3",
+  "version": "3.0.0",
   "private": true,
   "scripts": {
     "serve": "vue-cli-service serve",

--- a/public/index.html
+++ b/public/index.html
@@ -6,6 +6,10 @@
     <meta name="viewport" content="width=device-width,initial-scale=1.0" />
     <link rel="icon" href="<%= BASE_URL %>trynano-icon-sq.ico" />
     <title><%= htmlWebpackPlugin.options.title %></title>
+    <script
+      src="https://kit.fontawesome.com/35f9779b6f.js"
+      crossorigin="anonymous"
+    ></script>
   </head>
   <body>
     <noscript>

--- a/src/NanoApp.vue
+++ b/src/NanoApp.vue
@@ -101,6 +101,7 @@
                 type="primary"
                 plain
                 @click="increaseStep"
+                :disabled="!isCurrentStepComplete"
                 >{{ t('nanoApp.steppers.next') }}<i class="el-icon-right"></i
               ></el-button>
             </div>

--- a/src/NanoApp.vue
+++ b/src/NanoApp.vue
@@ -25,9 +25,11 @@
                     :label="'  ' + localeNameMapping[language]"
                     :value="language"
                   >
-                    <span class="select-locale-font" style="float: left">{{
-                      localeNameMapping[language]
-                    }}</span>
+                    <span
+                      class="select-locale-font"
+                      style="float: left; margin-right: 20px"
+                      >{{ localeNameMapping[language] }}</span
+                    >
                     <span
                       class="select-locale-font"
                       style="float: right; color: #8492a6; font-size: 13px"
@@ -201,7 +203,7 @@ export default {
     return {
       localeNameMapping: {
         en: 'English',
-        ptBr: 'Portuguese (Brazil)',
+        'pt-BR': 'Português brasileiro',
       },
     };
   },
@@ -228,23 +230,11 @@ export default {
         case 'tablet':
           return 12;
         case 'other':
-          return 10;
+          return 11;
         default:
-          return 10;
+          return 11;
       }
     },
-    // versionSpan() {
-    //   switch (this.$mq) {
-    //     case 'phone':
-    //       return 6;
-    //     case 'tablet':
-    //       return 6;
-    //     case 'other':
-    //       return 6;
-    //     default:
-    //       return 6;
-    //   }
-    // },
   },
   setup() {
     const { t, locale, availableLocales } = useI18n({ useScope: 'global' });

--- a/src/NanoApp.vue
+++ b/src/NanoApp.vue
@@ -2,159 +2,162 @@
 <template>
   <div class="flex-wrapper">
     <div>
-      <el-alert
-        :title="t('nanoApp.networkAlert')"
-        type="warning"
-        effect="dark"
-        center
-        show-icon
-      >
-      </el-alert>
-      <div :style="{ float: 'right', width: headerWidth }">
-        <el-row type="flex" justify="end" align="middle" class="header-row">
-          <el-col :span="languageSpan">
-            <el-select v-model="locale">
-              <template #prefix>
-                <i class="fas fa-globe-americas locale-icon"></i>
-              </template>
-              <el-option
-                v-for="language in availableLocales"
-                :key="language"
-                :label="'  ' + localeNameMapping[language]"
-                :value="language"
-              >
-                <span class="select-locale-font" style="float: left">{{
-                  localeNameMapping[language]
-                }}</span>
-                <span
-                  class="select-locale-font"
-                  style="float: right; color: #8492a6; font-size: 13px"
-                  >{{ language }}</span
-                >
-              </el-option>
-            </el-select>
-          </el-col>
-          <el-col :span="6">
-            <p class="version">v{{ version }}</p>
-          </el-col>
-        </el-row>
-      </div>
-    </div>
-    <div class="site-content">
-      <NanoIntro @revealStepsClicked="handleRevealStepsClicked"></NanoIntro>
-      <transition name="fade-in-down">
-        <div v-show="didRevealSteps">
-          <el-steps
-            :space="500"
-            class="steps"
-            :class="{
-              'steps-width-phone': $mq === 'phone',
-              'steps-width-tablet': $mq === 'tablet',
-              'steps-width-other': $mq === 'other',
-            }"
-            :active="currentStep"
-            align-center
-            finish-status="success"
-          >
-            <el-step
-              :title="t('nanoApp.steps.title', 1)"
-              :description="t('nanoApp.steps.description.one')"
-              icon="el-icon-coin"
-            ></el-step>
-            <el-step
-              :title="t('nanoApp.steps.title', 2)"
-              :description="t('nanoApp.steps.description.two')"
-              icon="el-icon-set-up"
-            ></el-step>
-            <el-step
-              :title="t('nanoApp.steps.title', 3)"
-              :description="t('nanoApp.steps.description.three')"
-              icon="el-icon-wallet"
-            ></el-step>
-            <el-step
-              :title="t('nanoApp.steps.title', 4)"
-              :description="t('nanoApp.steps.description.four')"
-              icon="el-icon-finished"
-            ></el-step>
-          </el-steps>
-          <div
-            class="step-section"
-            :class="{
-              'step-section-width-phone': $mq === 'phone',
-              'step-section-width-tablet': $mq === 'tablet',
-              'step-section-width-other': $mq === 'other',
-            }"
-          >
-            <div class="steppers">
-              <el-button
-                :style="{ visibility: currentStep > 0 ? 'visible' : 'hidden' }"
-                round
-                type="primary"
-                plain
-                icon="el-icon-back"
-                @click="decreaseStep"
-                >{{ t('nanoApp.steppers.previous') }}</el-button
-              >
-              <el-button
-                :style="{ visibility: currentStep < 4 ? 'visible' : 'hidden' }"
-                round
-                type="primary"
-                plain
-                @click="increaseStep"
-                :disabled="!isCurrentStepComplete"
-                >{{ t('nanoApp.steppers.next') }}<i class="el-icon-right"></i
-              ></el-button>
-            </div>
-            <el-card shadow="always" :body-style="{ backgroundColor: '#F4FAFF' }">
-              <vue-element-loading
-                :active="!didGenerateWallets"
-                background-color="#F4FAFF"
-                spinner="spinner"
-                color="#3b7bbf"
-                :text="t('nanoApp.generatingWallets')"
-              />
-              <transition :name="transitionDirection">
-                <div v-show="currentStep === 0">
-                  <NanoFaucetInfo
-                    :firstWalletData="firstWalletData"
-                    :recaptchaLoaded="recaptchaLoaded"
-                    :executeRecaptcha="executeRecaptcha"
-                  ></NanoFaucetInfo>
-                </div>
-              </transition>
-              <transition :name="transitionDirection">
-                <div v-show="currentStep === 1">
-                  <NanoDemo
-                    :firstWallet="firstWalletData"
-                    :secondWallet="secondWalletData"
-                    :recaptchaLoaded="recaptchaLoaded"
-                    :executeRecaptcha="executeRecaptcha"
-                  ></NanoDemo>
-                </div>
-              </transition>
-              <transition :name="transitionDirection">
-                <div v-show="currentStep === 2">
-                  <ClaimNano
-                    :firstWallet="firstWalletData"
-                    :secondWallet="secondWalletData"
-                    :originAddressMap="nanoOriginAddressMap"
-                    :recaptchaLoaded="recaptchaLoaded"
-                    :executeRecaptcha="executeRecaptcha"
-                  ></ClaimNano>
-                </div>
-              </transition>
-              <transition :name="transitionDirection">
-                <div v-show="currentStep === 4">
-                  <NanoResources
-                    :firstWallet="firstWalletData"
-                    :secondWallet="secondWalletData"
-                  ></NanoResources>
-                </div>
-              </transition>
-            </el-card>
+      <div class="content-vertical-align">
+        <el-alert
+          :title="t('nanoApp.networkAlert')"
+          type="warning"
+          effect="dark"
+          center
+          show-icon
+        >
+        </el-alert>
+        <div>
+          <div :style="{ float: 'right', width: headerWidth }">
+            <el-row type="flex" justify="end" align="middle" class="header-row">
+              <el-col :span="languageSpan">
+                <el-select v-model="locale">
+                  <template #prefix>
+                    <i class="fas fa-globe-americas locale-icon"></i>
+                  </template>
+                  <el-option
+                    v-for="language in availableLocales"
+                    :key="language"
+                    :label="'  ' + localeNameMapping[language]"
+                    :value="language"
+                  >
+                    <span class="select-locale-font" style="float: left">{{
+                      localeNameMapping[language]
+                    }}</span>
+                    <span
+                      class="select-locale-font"
+                      style="float: right; color: #8492a6; font-size: 13px"
+                      >{{ language }}</span
+                    >
+                  </el-option>
+                </el-select>
+              </el-col>
+              <el-col :span="6">
+                <p class="version">v{{ version }}</p>
+              </el-col>
+            </el-row>
           </div>
         </div>
-      </transition>
+        <div class="site-content">
+          <NanoIntro @revealStepsClicked="handleRevealStepsClicked"></NanoIntro>
+          <transition name="fade-in-down">
+            <div v-show="didRevealSteps">
+              <el-steps
+                :space="500"
+                class="steps"
+                :class="{
+                  'steps-width-phone': $mq === 'phone',
+                  'steps-width-tablet': $mq === 'tablet',
+                  'steps-width-other': $mq === 'other',
+                }"
+                :active="currentStep"
+                align-center
+                finish-status="success"
+              >
+                <el-step
+                  :title="t('nanoApp.steps.title', 1)"
+                  :description="t('nanoApp.steps.description.one')"
+                  icon="el-icon-coin"
+                ></el-step>
+                <el-step
+                  :title="t('nanoApp.steps.title', 2)"
+                  :description="t('nanoApp.steps.description.two')"
+                  icon="el-icon-set-up"
+                ></el-step>
+                <el-step
+                  :title="t('nanoApp.steps.title', 3)"
+                  :description="t('nanoApp.steps.description.three')"
+                  icon="el-icon-wallet"
+                ></el-step>
+                <el-step
+                  :title="t('nanoApp.steps.title', 4)"
+                  :description="t('nanoApp.steps.description.four')"
+                  icon="el-icon-finished"
+                ></el-step>
+              </el-steps>
+              <div
+                class="step-section"
+                :class="{
+                  'step-section-width-phone': $mq === 'phone',
+                  'step-section-width-tablet': $mq === 'tablet',
+                  'step-section-width-other': $mq === 'other',
+                }"
+              >
+                <div class="steppers">
+                  <el-button
+                    :style="{ visibility: currentStep > 0 ? 'visible' : 'hidden' }"
+                    round
+                    type="primary"
+                    plain
+                    icon="el-icon-back"
+                    @click="decreaseStep"
+                    >{{ t('nanoApp.steppers.previous') }}</el-button
+                  >
+                  <el-button
+                    :style="{ visibility: currentStep < 4 ? 'visible' : 'hidden' }"
+                    round
+                    type="primary"
+                    plain
+                    @click="increaseStep"
+                    >{{ t('nanoApp.steppers.next') }}<i class="el-icon-right"></i
+                  ></el-button>
+                </div>
+                <el-card shadow="always" :body-style="{ backgroundColor: '#F4FAFF' }">
+                  <vue-element-loading
+                    :active="!didGenerateWallets"
+                    background-color="#F4FAFF"
+                    spinner="spinner"
+                    color="#3b7bbf"
+                    :text="t('nanoApp.generatingWallets')"
+                  />
+                  <transition :name="transitionDirection">
+                    <div v-show="currentStep === 0">
+                      <NanoFaucetInfo
+                        :firstWalletData="firstWalletData"
+                        :recaptchaLoaded="recaptchaLoaded"
+                        :executeRecaptcha="executeRecaptcha"
+                      ></NanoFaucetInfo>
+                    </div>
+                  </transition>
+                  <transition :name="transitionDirection">
+                    <div v-show="currentStep === 1">
+                      <NanoDemo
+                        :firstWallet="firstWalletData"
+                        :secondWallet="secondWalletData"
+                        :recaptchaLoaded="recaptchaLoaded"
+                        :executeRecaptcha="executeRecaptcha"
+                      ></NanoDemo>
+                    </div>
+                  </transition>
+                  <transition :name="transitionDirection">
+                    <div v-show="currentStep === 2">
+                      <ClaimNano
+                        :firstWallet="firstWalletData"
+                        :secondWallet="secondWalletData"
+                        :originAddressMap="nanoOriginAddressMap"
+                        :recaptchaLoaded="recaptchaLoaded"
+                        :executeRecaptcha="executeRecaptcha"
+                      ></ClaimNano>
+                    </div>
+                  </transition>
+                  <transition :name="transitionDirection">
+                    <div v-show="currentStep === 4">
+                      <NanoResources
+                        :firstWallet="firstWalletData"
+                        :secondWallet="secondWalletData"
+                      ></NanoResources>
+                    </div>
+                  </transition>
+                </el-card>
+              </div>
+            </div>
+          </transition>
+        </div>
+      </div>
       <div class="push"></div>
     </div>
     <NanoFooter></NanoFooter>
@@ -206,7 +209,6 @@ export default {
         case 'phone':
           return '80%';
         case 'tabletSm':
-          return '60%';
         case 'tablet':
           return '40%';
         case 'other':
@@ -220,7 +222,7 @@ export default {
         case 'phone':
           return 18;
         case 'tabletSm':
-          return 14;
+          return 16;
         case 'tablet':
           return 12;
         case 'other':
@@ -229,6 +231,18 @@ export default {
           return 10;
       }
     },
+    // versionSpan() {
+    //   switch (this.$mq) {
+    //     case 'phone':
+    //       return 6;
+    //     case 'tablet':
+    //       return 6;
+    //     case 'other':
+    //       return 6;
+    //     default:
+    //       return 6;
+    //   }
+    // },
   },
   setup() {
     const { t, locale, availableLocales } = useI18n({ useScope: 'global' });
@@ -617,5 +631,13 @@ a:hover {
 
 .version {
   font-size: 14px;
+}
+
+.content-vertical-align {
+  margin: 0;
+  padding: 0;
+  width: 100%;
+  display: flex;
+  flex-direction: column;
 }
 </style>

--- a/src/NanoApp.vue
+++ b/src/NanoApp.vue
@@ -134,6 +134,7 @@ import { NANO } from '@nanobox/nano-client/dist/models';
 import { useReCaptcha } from 'vue-recaptcha-v3';
 import { ElMessage } from 'element-plus';
 import VueElementLoading from 'vue-element-loading';
+import { useI18n } from 'vue-i18n';
 import recaptcha from './util/recaptcha';
 import NanoIntro from './components/NanoIntro.vue';
 import NanoFaucetInfo from './components/NanoFaucetInfo.vue';
@@ -157,6 +158,7 @@ export default {
     VueElementLoading,
   },
   setup() {
+    const { t } = useI18n({ useScope: 'global' });
     const { emitter } = getCurrentInstance().appContext.config.globalProperties;
     const { recaptchaLoaded, executeRecaptcha } = useReCaptcha();
     const { getRecaptchaToken } = recaptcha();
@@ -378,6 +380,7 @@ export default {
     });
 
     return {
+      t,
       currentStep,
       decreaseStep,
       increaseStep,

--- a/src/NanoApp.vue
+++ b/src/NanoApp.vue
@@ -103,6 +103,7 @@
                     type="primary"
                     plain
                     @click="increaseStep"
+                    :disabled="!isCurrentStepComplete"
                     >{{ t('nanoApp.steppers.next') }}<i class="el-icon-right"></i
                   ></el-button>
                 </div>

--- a/src/NanoApp.vue
+++ b/src/NanoApp.vue
@@ -1,14 +1,45 @@
 /* eslint-disable operator-linebreak */
 <template>
-  <el-alert
-    :title="t('nanoApp.networkAlert')"
-    type="warning"
-    effect="dark"
-    center
-    show-icon
-  >
-  </el-alert>
   <div class="flex-wrapper">
+    <div>
+      <el-alert
+        :title="t('nanoApp.networkAlert')"
+        type="warning"
+        effect="dark"
+        center
+        show-icon
+      >
+      </el-alert>
+      <div :style="{ float: 'right', width: headerWidth }">
+        <el-row type="flex" justify="end" align="middle" class="header-row">
+          <el-col :span="languageSpan">
+            <el-select v-model="locale">
+              <template #prefix>
+                <i class="fas fa-globe-americas locale-icon"></i>
+              </template>
+              <el-option
+                v-for="language in availableLocales"
+                :key="language"
+                :label="'  ' + localeNameMapping[language]"
+                :value="language"
+              >
+                <span class="select-locale-font" style="float: left">{{
+                  localeNameMapping[language]
+                }}</span>
+                <span
+                  class="select-locale-font"
+                  style="float: right; color: #8492a6; font-size: 13px"
+                  >{{ language }}</span
+                >
+              </el-option>
+            </el-select>
+          </el-col>
+          <el-col :span="6">
+            <p class="version">v{{ version }}</p>
+          </el-col>
+        </el-row>
+      </div>
+    </div>
     <div class="site-content">
       <NanoIntro @revealStepsClicked="handleRevealStepsClicked"></NanoIntro>
       <transition name="fade-in-down">
@@ -138,6 +169,7 @@ import { useReCaptcha } from 'vue-recaptcha-v3';
 import { ElMessage } from 'element-plus';
 import VueElementLoading from 'vue-element-loading';
 import { useI18n } from 'vue-i18n';
+import { version } from '../package.json';
 import recaptcha from './util/recaptcha';
 import NanoIntro from './components/NanoIntro.vue';
 import NanoFaucetInfo from './components/NanoFaucetInfo.vue';
@@ -160,8 +192,46 @@ export default {
     NanoResources,
     VueElementLoading,
   },
+  data() {
+    return {
+      localeNameMapping: {
+        en: 'English',
+      },
+    };
+  },
+  computed: {
+    headerWidth() {
+      switch (this.$mq) {
+        case 'phone':
+          return '80%';
+        case 'tabletSm':
+          return '60%';
+        case 'tablet':
+          return '40%';
+        case 'other':
+          return '25%';
+        default:
+          return '25%';
+      }
+    },
+    languageSpan() {
+      switch (this.$mq) {
+        case 'phone':
+          return 18;
+        case 'tabletSm':
+          return 14;
+        case 'tablet':
+          return 12;
+        case 'other':
+          return 10;
+        default:
+          return 10;
+      }
+    },
+  },
   setup() {
-    const { t } = useI18n({ useScope: 'global' });
+    const { t, locale, availableLocales } = useI18n({ useScope: 'global' });
+
     const { emitter } = getCurrentInstance().appContext.config.globalProperties;
     const { recaptchaLoaded, executeRecaptcha } = useReCaptcha();
     const { getRecaptchaToken } = recaptcha();
@@ -384,6 +454,9 @@ export default {
 
     return {
       t,
+      locale,
+      availableLocales,
+      version,
       currentStep,
       decreaseStep,
       increaseStep,
@@ -522,5 +595,26 @@ a:hover {
 
 .grecaptcha-badge {
   opacity: 0;
+}
+
+.select-locale-font {
+  font-family: Avenir, Helvetica, Arial, sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+.locale-icon {
+  font-size: 1.2em;
+  position: relative;
+  top: calc(50% - 1.04em);
+  left: 5px;
+}
+
+.header-row {
+  margin: 10px auto;
+}
+
+.version {
+  font-size: 14px;
 }
 </style>

--- a/src/NanoApp.vue
+++ b/src/NanoApp.vue
@@ -201,6 +201,7 @@ export default {
     return {
       localeNameMapping: {
         en: 'English',
+        ptBr: 'Portuguese (Brazil)',
       },
     };
   },

--- a/src/NanoApp.vue
+++ b/src/NanoApp.vue
@@ -1,7 +1,7 @@
 /* eslint-disable operator-linebreak */
 <template>
   <el-alert
-    title="TryNano is currently facing difficulties while trying to communicate with the Nano network. Thank you for your understanding!"
+    :title="t('nanoApp.networkAlert')"
     type="warning"
     effect="dark"
     center
@@ -26,21 +26,25 @@
             finish-status="success"
           >
             <el-step
-              title="Step 1"
-              description="Grab Some Nano"
+              :title="t('nanoApp.steps.title', 1)"
+              :description="t('nanoApp.steps.description.one')"
               icon="el-icon-coin"
             ></el-step>
             <el-step
-              title="Step 2"
-              description="Try It Out"
+              :title="t('nanoApp.steps.title', 2)"
+              :description="t('nanoApp.steps.description.two')"
               icon="el-icon-set-up"
             ></el-step>
             <el-step
-              title="Step 3"
-              description="Set Up Your Wallet"
+              :title="t('nanoApp.steps.title', 3)"
+              :description="t('nanoApp.steps.description.three')"
               icon="el-icon-wallet"
             ></el-step>
-            <el-step title="Step 4" description="Done!" icon="el-icon-finished"></el-step>
+            <el-step
+              :title="t('nanoApp.steps.title', 4)"
+              :description="t('nanoApp.steps.description.four')"
+              icon="el-icon-finished"
+            ></el-step>
           </el-steps>
           <div
             class="step-section"
@@ -58,7 +62,7 @@
                 plain
                 icon="el-icon-back"
                 @click="decreaseStep"
-                >Previous Step</el-button
+                >{{ t('nanoApp.steppers.previous') }}</el-button
               >
               <el-button
                 :style="{ visibility: currentStep < 4 ? 'visible' : 'hidden' }"
@@ -67,7 +71,7 @@
                 plain
                 @click="increaseStep"
                 :disabled="!isCurrentStepComplete"
-                >Next Step <i class="el-icon-right"></i
+                >{{ t('nanoApp.steppers.next') }}<i class="el-icon-right"></i
               ></el-button>
             </div>
             <el-card shadow="always" :body-style="{ backgroundColor: '#F4FAFF' }">
@@ -76,7 +80,7 @@
                 background-color="#F4FAFF"
                 spinner="spinner"
                 color="#3b7bbf"
-                text="Generating Wallets..."
+                :text="t('nanoApp.generatingWallets')"
               />
               <transition :name="transitionDirection">
                 <div v-show="currentStep === 0">

--- a/src/NanoApp.vue
+++ b/src/NanoApp.vue
@@ -70,7 +70,6 @@
                 type="primary"
                 plain
                 @click="increaseStep"
-                :disabled="!isCurrentStepComplete"
                 >{{ t('nanoApp.steppers.next') }}<i class="el-icon-right"></i
               ></el-button>
             </div>

--- a/src/components/ClaimNano.vue
+++ b/src/components/ClaimNano.vue
@@ -10,7 +10,11 @@
       t('claimNano.secondSentence.nault')
     }}</a>
   </i18n-t>
-  <i18n-t keypath="claimNano.thirdSentence.main" tag="p">
+  <i18n-t
+    keypath="claimNano.thirdSentence.main"
+    tag="p"
+    style="font-size: 90%; opacity: 85%; margin-top: -10px"
+  >
     <a href="https://nanowallets.guide/" target="_blank">{{
       t('claimNano.thirdSentence.guide')
     }}</a>

--- a/src/components/ClaimNano.vue
+++ b/src/components/ClaimNano.vue
@@ -1,20 +1,22 @@
 <template>
-  <p>
-    To claim back your Nano, you'll need to set up a <strong>private wallet</strong> to
-    store it in.
-  </p>
-  <p>
-    The most popular wallets in the Nano community are
-    <a href="https://natrium.io/" target="_blank">Natrium</a> (Android/iOS) and
-    <a href="https://nault.cc" target="_blank">Nault</a> (Web/Desktop).
-  </p>
-  <p style="font-size: 90%; opacity: 85%; margin-top: -10px">
-    (For a more complete list of options, please visit
-    <a href="https://nanowallets.guide/" target="_blank">this guide</a>.)
-  </p>
+  <i18n-t keypath="claimNano.firstSentence.main" tag="p">
+    <strong>{{ t('claimNano.firstSentence.privateWallet') }}</strong>
+  </i18n-t>
+  <i18n-t keypath="claimNano.secondSentence.main" tag="p">
+    <a href="https://natrium.io/" target="_blank">{{
+      t('claimNano.secondSentence.natrium')
+    }}</a>
+    <a href="https://nault.cc" target="_blank">{{
+      t('claimNano.secondSentence.nault')
+    }}</a>
+  </i18n-t>
+  <i18n-t keypath="claimNano.thirdSentence.main" tag="p">
+    <a href="https://nanowallets.guide/" target="_blank">{{
+      t('claimNano.thirdSentence.guide')
+    }}</a>
+  </i18n-t>
   <p style="margin-top: 30px">
-    Once you've finished setting up your wallet, enter your new Nano wallet address below
-    and click send. That's it!
+    {{ t('claimNano.fourthSentence') }}
   </p>
   <el-row
     class="send-nano-row"
@@ -29,7 +31,7 @@
     <el-col :span="nanoAddressSpan">
       <el-input
         class="nano-address-input"
-        placeholder="Enter your Nano address..."
+        :placeholder="t('claimNano.addressPlaceholder')"
         v-model="receivingNanoAddress"
         clearable
         @input="validateNanoAddress"
@@ -39,7 +41,11 @@
       >
       </el-input>
       <div ref="validNanoAddressLabel" class="validNanoAddressLabel">
-        {{ isValidNanoAddress ? 'Valid Nano Address' : 'Invalid Nano Address' }}
+        {{
+          isValidNanoAddress
+            ? t('claimNano.validNanoAddress')
+            : t('claimNano.invalidNanoAddress')
+        }}
       </div>
     </el-col>
     <el-col :span="sendButtonSpan">
@@ -52,10 +58,12 @@
         :loading="sendingNano"
       >
         <div v-show="!sendingNano && !nanoSuccessfullySent">
-          Send <i class="el-icon-s-promotion"></i>
+          {{ t('claimNano.send') }} <i class="el-icon-s-promotion"></i>
         </div>
-        <div v-show="sendingNano && !nanoSuccessfullySent">Sending...</div>
-        <div v-show="!sendingNano && nanoSuccessfullySent">Sent!</div>
+        <div v-show="sendingNano && !nanoSuccessfullySent">
+          {{ t('claimNano.sending') }}
+        </div>
+        <div v-show="!sendingNano && nanoSuccessfullySent">{{ t('claimNano.sent') }}</div>
       </el-button></el-col
     >
   </el-row>
@@ -74,10 +82,14 @@
       }"
     >
       <div v-show="!returningNano && !nanoSuccessfullyReturned">
-        Return Back to Sender <i class="el-icon-s-promotion"></i>
+        {{ t('claimNano.returnToSender') }} <i class="el-icon-s-promotion"></i>
       </div>
-      <div v-show="returningNano && !nanoSuccessfullyReturned">Sending...</div>
-      <div v-show="!returningNano && nanoSuccessfullyReturned">Sent!</div>
+      <div v-show="returningNano && !nanoSuccessfullyReturned">
+        {{ t('claimNano.sending') }}
+      </div>
+      <div v-show="!returningNano && nanoSuccessfullyReturned">
+        {{ t('claimNano.sent') }}
+      </div>
     </el-button>
   </div>
 </template>
@@ -85,6 +97,7 @@
 import { ref, computed, getCurrentInstance } from 'vue';
 import { ElMessage } from 'element-plus';
 import { tools } from 'nanocurrency-web';
+import { useI18n } from 'vue-i18n';
 import recaptcha from '../util/recaptcha';
 import serverAPI from '../util/server_api';
 
@@ -124,6 +137,7 @@ export default {
     },
   },
   setup(props) {
+    const { t } = useI18n({ useScope: 'global' });
     const { emitter } = getCurrentInstance().appContext.config.globalProperties;
 
     const { getRecaptchaToken } = recaptcha();
@@ -265,6 +279,7 @@ export default {
     };
 
     return {
+      t,
       receivingNanoAddress,
       sendNanoClicked,
       validateNanoAddress,

--- a/src/components/FeedbackForm.vue
+++ b/src/components/FeedbackForm.vue
@@ -1,5 +1,9 @@
 <template>
-  <el-dialog title="Give Feedback" v-model="isDialogVisible" :width="dialogWidth">
+  <el-dialog
+    :title="t('feedbackForm.title')"
+    v-model="isDialogVisible"
+    :width="dialogWidth"
+  >
     <el-form
       :model="ruleForm"
       class="form"
@@ -8,20 +12,29 @@
       status-icon
       label-width="120px"
     >
-      <el-form-item label="Name" prop="name">
+      <el-form-item :label="t('feedbackForm.name.label')" prop="name">
         <el-input v-model="name" name="name"></el-input>
       </el-form-item>
-      <el-form-item label="Email" prop="email">
+      <el-form-item :label="t('feedbackForm.email.label')" prop="email">
         <el-input v-model="email" name="email"></el-input>
       </el-form-item>
-      <el-form-item label="Feedback Type">
+      <el-form-item :label="t('feedbackForm.feedbackType.label')">
         <el-radio-group v-model="feedbackType" name="feedback_type">
-          <el-radio label="Bug" name="feedback_type"></el-radio>
-          <el-radio label="Feature Request" name="feedback_type"></el-radio>
-          <el-radio label="Other" name="feedback_type"></el-radio>
+          <el-radio
+            :label="t('feedbackForm.feedbackType.type.bug')"
+            name="feedback_type"
+          ></el-radio>
+          <el-radio
+            :label="t('feedbackForm.feedbackType.type.featureRequest')"
+            name="feedback_type"
+          ></el-radio>
+          <el-radio
+            :label="t('feedbackForm.feedbackType.type.other')"
+            name="feedback_type"
+          ></el-radio>
         </el-radio-group>
       </el-form-item>
-      <el-form-item label="Message" prop="message">
+      <el-form-item :label="t('feedbackForm.message.label')" prop="message">
         <el-input
           type="textarea"
           v-model="message"
@@ -33,12 +46,14 @@
     </el-form>
     <template #footer>
       <span class="dialog-footer">
-        <el-button @click="hideFeedbackForm">Cancel</el-button>
+        <el-button @click="hideFeedbackForm">{{
+          t('feedbackForm.buttons.cancel')
+        }}</el-button>
         <el-button
           :disabled="name === '' || email === '' || message === ''"
           type="primary"
           @click="onSubmitFeedbackForm"
-          >Confirm</el-button
+          >{{ t('feedbackForm.buttons.confirm') }}</el-button
         >
       </span>
     </template>
@@ -46,11 +61,12 @@
 </template>
 <script>
 import { ref, getCurrentInstance } from 'vue';
+import { useI18n } from 'vue-i18n';
 import emailjs from 'emailjs-com';
 import { ElMessage } from 'element-plus';
 
 export default {
-  name: '',
+  name: 'FeedbackForm',
   props: {
     feedbackDialogVisible: Boolean,
   },
@@ -69,6 +85,7 @@ export default {
     },
   },
   setup(props) {
+    const { t } = useI18n({ useScope: 'global' });
     const { emitter } = getCurrentInstance().appContext.config.globalProperties;
 
     const isDialogVisible = ref(props.feedbackDialogVisible);
@@ -85,7 +102,7 @@ export default {
 
     const name = ref('');
     const email = ref('');
-    const feedbackType = ref('Bug');
+    const feedbackType = ref(t('feedbackForm.feedbackType.type.bug'));
     const message = ref('');
 
     const ruleForm = ref({
@@ -96,14 +113,22 @@ export default {
     });
 
     const rules = ref({
-      name: [{ required: true, message: 'Please enter a name', trigger: 'blur' }],
+      name: [{ required: true, message: t('feedbackForm.name.rule'), trigger: 'blur' }],
       email: [
-        { required: true, message: 'Please enter an email', trigger: 'blur' },
-        { type: 'email', message: 'Invalid email address', trigger: 'blur' },
+        {
+          required: true,
+          message: t('feedbackForm.email.rules.required'),
+          trigger: 'blur',
+        },
+        { type: 'email', message: t('feedbackForm.email.rules.email'), trigger: 'blur' },
       ],
       message: [
-        { required: true, message: 'Please enter a message', trigger: 'blur' },
-        { min: 10, message: 'Please enter more than 10 characters', trigger: 'blur' },
+        {
+          required: true,
+          message: t('feedbackForm.message.rules.required'),
+          trigger: 'blur',
+        },
+        { min: 10, message: t('feedbackForm.message.rules.min'), trigger: 'blur' },
       ],
     });
 
@@ -135,7 +160,7 @@ export default {
                 // Reset form field
                 name.value = '';
                 email.value = '';
-                feedbackType.value = 'Bug';
+                feedbackType.value = t('feedbackForm.feedbackType.type.bug');
                 message.value = '';
               } else {
                 ElMessage({
@@ -156,6 +181,7 @@ export default {
     };
 
     return {
+      t,
       isDialogVisible,
       hideFeedbackForm,
       onSubmitFeedbackForm,

--- a/src/components/NanoFaucetInfo.vue
+++ b/src/components/NanoFaucetInfo.vue
@@ -26,19 +26,19 @@
             <span
               :style="{ paddingLeft: $mq !== 'phone' ? '30px' : '0px' }"
               class="faucet-text"
-              >Use the TryNano Faucet </span
+              >{{ t('nanoFaucetInfo.faucetButton') }}</span
             ><span class="faucet-emoji">🚰</span>
           </div>
           <div v-show="nanoFaucetPending && !nanoFaucetCompleted">
-            <span class="faucet-text">Requesting Nano from Faucet... </span>
+            <span class="faucet-text">{{ t('nanoFaucetInfo.requestingFaucet') }}</span>
           </div>
           <div v-show="!nanoFaucetPending && nanoFaucetCompleted && !nanoRecieved">
             <span class="faucet-text"
-              >Faucet Nano sent! Receiving pending Nano from Faucet...
+              >{{ t('nanoFaucetInfo.receivePendingFromFaucet') }}
             </span>
           </div>
           <div v-show="!nanoFaucetPending && nanoFaucetCompleted && nanoRecieved">
-            <span class="faucet-text">Faucet Nano Received!</span>
+            <span class="faucet-text">{{ t('nanoFaucetInfo.faucetReceived') }}</span>
           </div>
         </div>
       </el-button>
@@ -49,30 +49,41 @@
         background-color="#F4FAFF"
         spinner="spinner"
         color="#3b7bbf"
-        text="Getting Faucet Info..."
+        :text="t('nanoFaucetInfo.gettingFaucetInfo')"
       />
-      <el-col :span="faucetInfoSpan"
-        ><p class="faucet-balance-info-items">
-          Faucet balance: <b>{{ faucetBalance }} Ñ</b>
-        </p></el-col
-      >
-      <el-col :span="faucetInfoSpan"
-        ><p class="faucet-balance-info-items">
-          Faucet payout: <b>{{ faucetPayout }}</b>
-        </p></el-col
-      >
+      <el-col :span="faucetInfoSpan">
+        <i18n-t
+          keypath="nanoFaucetInfo.faucetBalance.main"
+          tag="p"
+          class="faucet-balance-info-items"
+        >
+          <b>{{ t('nanoFaucetInfo.faucetBalance.balance', { faucetBalance }) }}</b>
+        </i18n-t>
+      </el-col>
+      <el-col :span="faucetInfoSpan">
+        <i18n-t
+          keypath="nanoFaucetInfo.faucetPayout.main"
+          tag="p"
+          class="faucet-balance-info-items"
+        >
+          <b>{{ t('nanoFaucetInfo.faucetPayout.payout', { faucetPayout }) }}</b>
+        </i18n-t>
+      </el-col>
     </el-row>
-    <el-divider content-position="center"><div>OR</div></el-divider>
-    <p class="maintext">
-      Go to
-      <a href="https://www.nano-faucet.org" target="_blank">nano-faucet.org</a> and paste
-      the generated wallet address below.
-    </p>
-    <p class="subtext">
-      (<u>Note</u>: If you've received a tip from someone using NanoTipBot and would like
-      to use that instead, use the !withdraw command outlined
-      <a href="https://nanotipbot.com/" target="_blank">here</a>.)
-    </p>
+    <el-divider content-position="center"
+      ><div>{{ t('nanoFaucetInfo.dividerText') }}</div></el-divider
+    >
+    <i18n-t keypath="nanoFaucetInfo.firstSentence.main" tag="p" class="maintext">
+      <a href="https://www.nano-faucet.org" target="_blank">{{
+        t('nanoFaucetInfo.firstSentence.faucetUrl')
+      }}</a>
+    </i18n-t>
+    <i18n-t keypath="nanoFaucetInfo.secondSentence.main" tag="p" class="subtext">
+      <u>{{ t('nanoFaucetInfo.secondSentence.note') }}</u>
+      <a href="https://nanotipbot.com/" target="_blank">{{
+        t('nanoFaucetInfo.secondSentence.nanoTipBotUrl')
+      }}</a>
+    </i18n-t>
     <div>
       <el-popover
         class="popover"
@@ -83,11 +94,15 @@
         <template #reference>
           <i class="el-icon-question wallet-tooltip pointer"></i>
         </template>
-        <div style="word-break: keep-all">
-          A <strong><u>wallet address</u></strong> is a unique identifier that serves as a
-          virtual location where cryptocurrency can be sent/received, similar to having an
-          email address!
-        </div>
+        <i18n-t
+          keypath="nanoFaucetInfo.popover.main"
+          tag="div"
+          style="word-break: keep-all"
+        >
+          <strong
+            ><u>{{ t('nanoFaucetInfo.popover.walletAddress') }}</u></strong
+          >
+        </i18n-t>
       </el-popover>
       <el-tooltip
         effect="dark"
@@ -97,7 +112,7 @@
       >
         <div
           style="display: inline-block; margin: 16px 0px"
-          @mouseenter="copyPrompt = 'Copy Address'"
+          @mouseenter="copyPrompt = t('nanoFaucetInfo.tooltip.copyAddress')"
           @mouseover="hoverOnCopyAddress = true"
           @mouseleave="hoverOnCopyAddress = false"
           class="overflow"
@@ -105,14 +120,17 @@
           v-clipboard:copy="walletAccount.address"
           v-clipboard:success="onAddressCopySuccess"
         >
-          <b>Generated wallet address</b>:
+          <b>{{ t('nanoFaucetInfo.generatedWalletAddress') }}</b
+          >:
           <span>{{ walletAccount.address }}</span>
           <img class="logo" src="../assets/copy.png" />
         </div>
       </el-tooltip>
     </div>
     <strong style="display: block">
-      <div style="display: inline-block">Status:&ensp;</div>
+      <div style="display: inline-block">
+        {{ t('nanoFaucetInfo.depositStatus.main') }}&ensp;
+      </div>
       <div
         style="display: inline-block"
         :class="{ waiting: !nanoRecieved, received: nanoRecieved }"
@@ -122,8 +140,12 @@
     </strong>
     <div v-show="walletBalance > 0">
       <div style="display: block">
-        <strong style="display: inline-block">Balance:&ensp;</strong>
-        <div class="overflow" style="display: inline-block">{{ walletBalance }} Ñ</div>
+        <strong style="display: inline-block"
+          >{{ t('nanoFaucetInfo.walletBalance.main') }}&ensp;</strong
+        >
+        <div class="overflow" style="display: inline-block">
+          {{ t('nanoFaucetInfo.walletBalance.amount', { walletBalance }) }}
+        </div>
       </div>
     </div>
   </div>
@@ -131,6 +153,7 @@
 
 <script>
 import { ref, computed, getCurrentInstance, onMounted } from 'vue';
+import { useI18n } from 'vue-i18n';
 import { ElMessage } from 'element-plus';
 import recaptcha from '../util/recaptcha';
 import serverAPI from '../util/server_api';
@@ -169,6 +192,7 @@ export default {
     },
   },
   setup(props) {
+    const { t } = useI18n({ useScope: 'global' });
     const { emitter } = getCurrentInstance().appContext.config.globalProperties;
     const { getRecaptchaToken } = recaptcha();
     const { getNanoFromFaucet } = serverAPI();
@@ -177,9 +201,9 @@ export default {
     const faucetBalance = ref(0);
     const faucetPayout = ref('');
     const nanoRecieved = ref(false);
-    const depositStatus = ref('Not Received');
+    const depositStatus = ref(t('nanoFaucetInfo.depositStatus.notReceived'));
     const hoverOnCopyAddress = ref(false);
-    const copyPrompt = ref('Copy Address');
+    const copyPrompt = ref(t('nanoFaucetInfo.tooltip.copyAddress'));
     const walletBalance = ref(0);
     const walletAccount = computed(() => props.firstWalletData);
 
@@ -231,7 +255,7 @@ export default {
     emitter.on('nano-received', (receiveData) => {
       if (receiveData.address === walletAccount.value.address) {
         if (!nanoRecieved.value && receiveData.balance > 0) {
-          depositStatus.value = 'Received!';
+          depositStatus.value = t('nanoFaucetInfo.depositStatus.received');
           nanoRecieved.value = true;
           walletBalance.value = receiveData.balance;
           emitter.emit('step-completed', 'first');
@@ -240,10 +264,11 @@ export default {
     });
 
     const onAddressCopySuccess = () => {
-      copyPrompt.value = 'Copied!';
+      copyPrompt.value = t('nanoFaucetInfo.tooltip.copiedAddress');
     };
 
     return {
+      t,
       nanoRecieved,
       depositStatus,
       hoverOnCopyAddress,

--- a/src/components/NanoFooter.vue
+++ b/src/components/NanoFooter.vue
@@ -2,58 +2,54 @@
 <template>
   <footer class="footer">
     <div style="display: block">
-      <span class="footer-content">
-        Created by
-        <a href="https://www.linkedin.com/in/omarbaradei/" target="_blank"
-          >Omar Baradei</a
-        >
-        and
-        <a href="https://www.linkedin.com/in/patricssss/" target="_blank">Patrick Smith</a
-        >.
-      </span>
-      <span class="footer-content">
-        Link to
-        <a href="https://github.com/OmarB97/trynano" target="_blank">GitHub</a>.
-      </span>
-      <span class="footer-content">
-        Donate to the TryNano Faucet:
+      <i18n-t keypath="nanoFooter.createdBy.main" tag="span" class="footer-content">
+        <a href="https://www.linkedin.com/in/omarbaradei/" target="_blank">{{
+          t('nanoFooter.createdBy.omar')
+        }}</a>
+        <a href="https://www.linkedin.com/in/patricssss/" target="_blank">{{
+          t('nanoFooter.createdBy.patrick')
+        }}</a>
+      </i18n-t>
+      <i18n-t keypath="nanoFooter.github.main" tag="span" class="footer-content">
+        <a href="https://github.com/OmarB97/trynano" target="_blank">{{
+          t('nanoFooter.github.url')
+        }}</a>
+      </i18n-t>
+      <i18n-t keypath="nanoFooter.faucet" tag="span" class="footer-content">
         <a
           href="https://nanocrawler.cc/explorer/account/nano_1r71ir93w6ymq9bmjbbz7zmqngj54uhgcdjgrjzcpk5bog3rs5t7ijh47y7w/history"
           target="_blank"
           :class="{ 'footer-content-phone': $mq === 'phone' }"
           >nano_1r71ir93w6ymq9bmjbbz7zmqngj54uhgcdjgrjzcpk5bog3rs5t7ijh47y7w</a
-        >.
-      </span>
-      <span class="footer-content">
-        Tips accepted at:
+        >
+      </i18n-t>
+      <i18n-t keypath="nanoFooter.tips" tag="span" class="footer-content">
         <a
           href="https://nanocrawler.cc/explorer/account/nano_17yrgm818r4348g4r61oc7x3w6nd68ji85686d5xo3nt455znb65zafaofrq/history"
           target="_blank"
           :class="{ 'footer-content-phone': $mq === 'phone' }"
           >nano_17yrgm818r4348g4r61oc7x3w6nd68ji85686d5xo3nt455znb65zafaofrq</a
-        >.
-      </span>
-      <span class="footer-content">
-        Give feedback
-        <a class="feedback-link" @click="toggleFeedbackDialogVisibility(true)">here</a>.
-      </span>
-      <div class="footer-content recaptcha-disclaimer">
-        This site is protected by reCAPTCHA and the
+        >
+      </i18n-t>
+      <i18n-t keypath="nanoFooter.feedback.main" tag="span" class="footer-content">
+        <a class="feedback-link" @click="toggleFeedbackDialogVisibility(true)">{{
+          t('nanoFooter.feedback.feedbackLink')
+        }}</a>
+      </i18n-t>
+      <i18n-t keypath="nanoFooter.recaptcha.main" tag="div" class="footer-content">
         <a
           href="https://policies.google.com/privacy"
           target="_blank"
           :class="{ 'footer-content-phone': $mq === 'phone' }"
-          >Google Privacy Policy</a
+          >{{ t('nanoFooter.recaptcha.policy') }}</a
         >
-        and
         <a
           href="https://policies.google.com/terms"
           target="_blank"
           :class="{ 'footer-content-phone': $mq === 'phone' }"
-          >Terms of Service</a
+          >{{ t('nanoFooter.recaptcha.tos') }}</a
         >
-        apply.
-      </div>
+      </i18n-t>
       <FeedbackForm
         :feedbackDialogVisible="feedbackDialogVisible"
         @hideFeedbackForm="toggleFeedbackDialogVisibility(false)"
@@ -64,6 +60,7 @@
 
 <script>
 import { ref, getCurrentInstance } from 'vue';
+import { useI18n } from 'vue-i18n';
 import FeedbackForm from './FeedbackForm.vue';
 
 export default {
@@ -72,6 +69,7 @@ export default {
     FeedbackForm,
   },
   setup() {
+    const { t } = useI18n({ useScope: 'global' });
     const { emitter } = getCurrentInstance().appContext.config.globalProperties;
 
     const feedbackDialogVisible = ref(false);
@@ -85,6 +83,7 @@ export default {
     });
 
     return {
+      t,
       feedbackDialogVisible,
       toggleFeedbackDialogVisibility,
     };
@@ -117,9 +116,4 @@ export default {
   overflow-wrap: break-word;
   max-width: 100%;
 }
-
-/* .recaptcha-disclaimer {
-  margin-top: 7px;
-  margin-bottom: -5px;
-} */
 </style>

--- a/src/components/NanoIntro.vue
+++ b/src/components/NanoIntro.vue
@@ -2,16 +2,13 @@
   <div class="intro">
     <img class="logo" src="../assets/trynano_full.png" />
     <h3>
-      TryNano demonstrates how fast and simple Nano transactions are by giving you two
-      wallets to send Nano back and forth between each other.
+      {{ t('nanoIntro.firstSentence') }}
     </h3>
-    <h5>
-      <strong>What is Nano?</strong> Nano (NANO) is a peer-to-peer digital currency
-      designed to provide instant transactions, zero fees, and scalability, all while
-      being eco-friendly.
-    </h5>
+    <i18n-t keypath="nanoIntro.secondSentence.main" tag="h5">
+      <strong>{{ t('nanoIntro.secondSentence.whatIsNano') }}</strong>
+    </i18n-t>
     <ClickToReveal
-      :revealText="'Click here to try it out yourself!'"
+      :revealText="t('nanoIntro.revealText')"
       :clickable="true"
       :shouldBoldText="true"
       :sizeFactor="1"
@@ -22,6 +19,7 @@
 
 <script>
 import { ref } from 'vue';
+import { useI18n } from 'vue-i18n';
 import ClickToReveal from './common/ClickToReveal.vue';
 
 export default {
@@ -29,6 +27,7 @@ export default {
   components: { ClickToReveal },
   emits: ['revealStepsClicked'],
   setup(props, context) {
+    const { t } = useI18n({ useScope: 'global' });
     const revealStepsClicked = ref(false);
 
     const handleRevealStepsClicked = () => {
@@ -36,7 +35,7 @@ export default {
       context.emit('revealStepsClicked');
     };
 
-    return { revealStepsClicked, handleRevealStepsClicked };
+    return { t, revealStepsClicked, handleRevealStepsClicked };
   },
 };
 </script>

--- a/src/components/NanoResources.vue
+++ b/src/components/NanoResources.vue
@@ -1,13 +1,12 @@
 <template>
   <div class="resources">
-    <h3 class="headline">&#127881; Thanks for using TryNano! &#127881;</h3>
-    <div>
-      For a comprehensive list of resources related to Nano including the core team,
-      social media channels, where to buy Nano, and more, please visit
-      <a href="https://nanolinks.info/" target="_blank">nanolinks.info</a>.
-    </div>
-    <div class="donation">
-      If you liked this experience, please consider donating to me at
+    <h3 class="headline">&#127881; {{ t('nanoResources.title') }} &#127881;</h3>
+    <i18n-t keypath="nanoResources.firstSentence.main" tag="div">
+      <a href="https://nanolinks.info/" target="_blank">{{
+        t('nanoResources.firstSentence.nanoLinksUrl')
+      }}</a>
+    </i18n-t>
+    <i18n-t keypath="nanoResources.secondSentence.main" tag="div" class="donation">
       <a
         class="nano-address"
         :class="{
@@ -18,7 +17,6 @@
         target="_blank"
         >nano_17yrgm818r4348g4r61oc7x3w6nd68ji85686d5xo3nt455znb65zafaofrq</a
       >
-      or the TryNano Faucet
       <a
         class="nano-address"
         :class="{
@@ -29,12 +27,19 @@
         target="_blank"
         >nano_1r71ir93w6ymq9bmjbbz7zmqngj54uhgcdjgrjzcpk5bog3rs5t7ijh47y7w</a
       >
-      to help keep the website up and running!
-    </div>
+    </i18n-t>
   </div>
 </template>
 <script>
-export default {};
+import { useI18n } from 'vue-i18n';
+
+export default {
+  name: 'NanoResources',
+  setup() {
+    const { t } = useI18n({ useScope: 'global' });
+    return { t };
+  },
+};
 </script>
 <style>
 .resources {

--- a/src/components/demo/NanoDemo.vue
+++ b/src/components/demo/NanoDemo.vue
@@ -35,7 +35,7 @@
             <span class="arrow"> →</span>
           </div>
           <div class="nano-button" v-show="disableNanoA && sendingNanoA">
-            {{ t('nanoDemo.demo.sending') }}
+            {{ t('demo.nanoDemo.sending') }}
           </div>
           <div
             v-show="
@@ -45,10 +45,10 @@
               !sendingNanoA
             "
           >
-            {{ t('nanoDemo.demo.sent') }}
+            {{ t('demo.nanoDemo.sent') }}
           </div>
           <div class="nano-button" v-show="waitingForReceiveNanoA">
-            {{ t('nanoDemo.demo.confirmingReceivedNano') }}
+            {{ t('demo.nanoDemo.confirmingReceivedNano') }}
           </div></el-button
         >
       </el-col>
@@ -86,7 +86,7 @@
             }}
           </div>
           <div class="nano-button" v-show="disableNanoB && sendingNanoB">
-            {{ t('nanoDemo.demo.sending') }}
+            {{ t('demo.nanoDemo.sending') }}
           </div>
           <div
             v-show="
@@ -96,10 +96,10 @@
               !sendingNanoB
             "
           >
-            {{ t('nanoDemo.demo.sent') }}
+            {{ t('demo.nanoDemo.sent') }}
           </div>
           <div class="nano-button" v-show="waitingForReceiveNanoB">
-            {{ t('nanoDemo.demo.confirmingReceivedNano') }}
+            {{ t('demo.nanoDemo.confirmingReceivedNano') }}
           </div></el-button
         >
       </el-col>
@@ -207,10 +207,10 @@ export default {
         !transactionEndTimeMs.value ||
         transactionEndTimeMs.value === 0
       ) {
-        return t('nanoDemo.demo.transactionTime.default');
+        return t('demo.nanoDemo.transactionTime.default');
       }
 
-      const res = t('nanoDemo.demo.transactionTime.time', {
+      const res = t('demo.nanoDemo.transactionTime.time', {
         time: Math.abs(
           (transactionEndTimeMs.value - transactionStartTimeMs.value) / 1000.0
         ).toString(),

--- a/src/components/demo/NanoDemo.vue
+++ b/src/components/demo/NanoDemo.vue
@@ -1,14 +1,13 @@
 <template>
   <div class="demo">
     <p>
-      Try sending some nano back and forth between these two wallets to get a feel for
-      just how quick and easy it is to use Nano!
+      {{ t('demo.nanoDemo.firstSentence') }}
     </p>
     <el-row type="flex" class="row-bg" justify="center" align="middle">
       <el-col :span="walletSpan">
         <NanoWallet
           class="wallet"
-          walletLetter="A"
+          :walletLetter="t('demo.nanoDemo.firstWalletLetter')"
           :walletAddress="firstWallet.address"
           :walletBalance="firstWallet.balance"
         ></NanoWallet>
@@ -16,7 +15,7 @@
           type="primary"
           :size="buttonSize"
           plain
-          @click="sendNanoClicked('B')"
+          @click="sendNanoClicked(t('demo.nanoDemo.secondWalletLetter'))"
           :loading="sendingNanoA || waitingForReceiveNanoA"
           :disabled="disableNanoA"
           ><div
@@ -24,25 +23,32 @@
             v-show="
               !waitingForReceiveNanoA &&
               (isInitialNanoA ||
-                lastWalletClicked === 'B' ||
+                lastWalletClicked === t('demo.nanoDemo.secondWalletLetter') ||
                 (!disableNanoA && !sendingNanoA))
             "
           >
-            Send to Wallet B <span class="arrow">→</span>
+            {{
+              t('demo.nanoDemo.sendToWallet', {
+                walletLetter: t('demo.nanoDemo.secondWalletLetter'),
+              })
+            }}
+            <span class="arrow"> →</span>
           </div>
-          <div class="nano-button" v-show="disableNanoA && sendingNanoA">Sending...</div>
+          <div class="nano-button" v-show="disableNanoA && sendingNanoA">
+            {{ t('nanoDemo.demo.sending') }}
+          </div>
           <div
             v-show="
               !isInitialNanoA &&
-              lastWalletClicked !== 'B' &&
+              lastWalletClicked !== t('demo.nanoDemo.secondWalletLetter') &&
               disableNanoA &&
               !sendingNanoA
             "
           >
-            Sent!
+            {{ t('nanoDemo.demo.sent') }}
           </div>
           <div class="nano-button" v-show="waitingForReceiveNanoA">
-            Confirming Received Nano...
+            {{ t('nanoDemo.demo.confirmingReceivedNano') }}
           </div></el-button
         >
       </el-col>
@@ -52,7 +58,7 @@
       <el-col :span="walletSpan">
         <NanoWallet
           class="wallet"
-          walletLetter="B"
+          :walletLetter="t('demo.nanoDemo.secondWalletLetter')"
           :walletAddress="secondWallet.address"
           :walletBalance="secondWallet.balance"
         ></NanoWallet>
@@ -60,7 +66,7 @@
           type="primary"
           plain
           :size="buttonSize"
-          @click="sendNanoClicked('A')"
+          @click="sendNanoClicked(t('demo.nanoDemo.firstWalletLetter'))"
           :loading="sendingNanoB || waitingForReceiveNanoB"
           :disabled="disableNanoB"
           ><div
@@ -68,26 +74,32 @@
             v-show="
               !waitingForReceiveNanoB &&
               (isInitialNanoB ||
-                lastWalletClicked === 'A' ||
+                lastWalletClicked === t('demo.nanoDemo.firstWalletLetter') ||
                 (!disableNanoB && !sendingNanoB))
             "
           >
-            <span class="arrow">←</span>
-            Send to Wallet A
+            <span class="arrow">← </span>
+            {{
+              t('demo.nanoDemo.sendToWallet', {
+                walletLetter: t('demo.nanoDemo.firstWalletLetter'),
+              })
+            }}
           </div>
-          <div class="nano-button" v-show="disableNanoB && sendingNanoB">Sending...</div>
+          <div class="nano-button" v-show="disableNanoB && sendingNanoB">
+            {{ t('nanoDemo.demo.sending') }}
+          </div>
           <div
             v-show="
               !isInitialNanoB &&
-              lastWalletClicked !== 'A' &&
+              lastWalletClicked !== t('demo.nanoDemo.firstWalletLetter') &&
               disableNanoB &&
               !sendingNanoB
             "
           >
-            Sent!
+            {{ t('nanoDemo.demo.sent') }}
           </div>
           <div class="nano-button" v-show="waitingForReceiveNanoB">
-            Confirming Received Nano...
+            {{ t('nanoDemo.demo.confirmingReceivedNano') }}
           </div></el-button
         >
       </el-col>
@@ -108,6 +120,7 @@
 
 <script>
 import { computed, ref, getCurrentInstance } from 'vue';
+import { useI18n } from 'vue-i18n';
 import { ElMessage } from 'element-plus';
 import NanoWallet from './NanoWallet.vue';
 import NanoTransactionResults from './NanoTransactionResults.vue';
@@ -167,6 +180,7 @@ export default {
     },
   },
   setup(props) {
+    const { t } = useI18n({ useScope: 'global' });
     const { emitter } = getCurrentInstance().appContext.config.globalProperties;
 
     const { getRecaptchaToken } = recaptcha();
@@ -193,12 +207,14 @@ export default {
         !transactionEndTimeMs.value ||
         transactionEndTimeMs.value === 0
       ) {
-        return 'N/A';
+        return t('nanoDemo.demo.transactionTime.default');
       }
 
-      const res = `${Math.abs(
-        (transactionEndTimeMs.value - transactionStartTimeMs.value) / 1000.0
-      ).toString()} seconds`;
+      const res = t('nanoDemo.demo.transactionTime.time', {
+        time: Math.abs(
+          (transactionEndTimeMs.value - transactionStartTimeMs.value) / 1000.0
+        ).toString(),
+      });
       return res;
     });
 
@@ -226,11 +242,11 @@ export default {
       );
 
       transactionStartTimeMs.value = Date.now();
-      if (receivingWalletLetter === 'B') {
+      if (receivingWalletLetter === t('demo.nanoDemo.secondWalletLetter')) {
         // send from Wallet A to Wallet B
         isInitialNanoA.value = false;
         sendingNanoA.value = true;
-        lastWalletClicked.value = 'A';
+        lastWalletClicked.value = t('demo.nanoDemo.firstWalletLetter');
 
         const res = await sendNano(
           token,
@@ -247,11 +263,11 @@ export default {
             type: 'error',
           });
         }
-      } else if (receivingWalletLetter === 'A') {
+      } else if (receivingWalletLetter === t('demo.nanoDemo.firstWalletLetter')) {
         // send from Wallet B to Wallet A
         isInitialNanoB.value = false;
         sendingNanoB.value = true;
-        lastWalletClicked.value = 'B';
+        lastWalletClicked.value = t('demo.nanoDemo.secondWalletLetter');
 
         const res = await sendNano(
           token,
@@ -314,6 +330,7 @@ export default {
     });
 
     return {
+      t,
       isInitialNanoA,
       isInitialNanoB,
       sendingNanoA,

--- a/src/components/demo/NanoTransactionResults.vue
+++ b/src/components/demo/NanoTransactionResults.vue
@@ -9,32 +9,48 @@
   >
     <el-card shadow="always" :body-style="{ width: '80%', margin: '0px auto 10px auto' }">
       <div class="card-content">
-        <h3 class="card-title">Transaction Results</h3>
+        <h3 class="card-title">{{ t('demo.nanoTransactionResults.title') }}</h3>
         <div class="no-transaction-placeholder" v-show="!didInitiateFirstTransaction">
-          Send Nano between the two wallets to start a transaction!
+          {{ t('demo.nanoTransactionResults.placeholder') }}
         </div>
         <div v-show="showTransactionResults">
           <div style="display: block">
-            <strong style="display: inline-block">Transaction Time:&ensp;</strong>
-            <div style="display: inline-block">{{ transactionTime }}</div>
+            <strong style="display: inline-block"
+              >{{ t('demo.nanoTransactionResults.transactionTime.label') }}&ensp;</strong
+            >
+            <div style="display: inline-block">
+              {{
+                t('demo.nanoTransactionResults.transactionTime.time', { transactionTime })
+              }}
+            </div>
           </div>
           <div style="display: block">
-            <strong style="display: inline-block">Transaction Fees:&ensp;</strong>
-            <div style="display: inline-block">None</div>
+            <strong style="display: inline-block"
+              >{{ t('demo.nanoTransactionResults.transactionFees.label') }}&ensp;</strong
+            >
+            <div style="display: inline-block">
+              {{ t('demo.nanoTransactionResults.transactionFees.fees') }}
+            </div>
           </div>
           <div style="display: block">
-            <strong style="display: inline-block">Energy Consumption:&ensp;</strong>
-            <div style="display: inline-block">~ 0.000112 kWh</div>
+            <strong style="display: inline-block"
+              >{{
+                t('demo.nanoTransactionResults.energyConsumption.label')
+              }}&ensp;</strong
+            >
+            <div style="display: inline-block">
+              {{ t('demo.nanoTransactionResults.energyConsumption.usage') }}
+            </div>
           </div>
           <div v-show="confirmationSendHash !== null" style="display: block">
             <strong style="display: inline-block"
-              >Link to sent confirmation block&ensp;</strong
+              >{{ t('demo.nanoTransactionResults.sendConfirmationBlock') }}&ensp;</strong
             >
             <a
               style="display: inline-block"
               :href="`https://nanocrawler.cc/explorer/block/${confirmationSendHash}`"
               target="_blank"
-              >on NanoCrawler</a
+              >{{ t('demo.nanoTransactionResults.nanoCrawlerLink') }}</a
             >
           </div>
           <div
@@ -42,13 +58,15 @@
             style="display: block"
           >
             <strong style="display: inline-block"
-              >Link to received confirmation block&ensp;</strong
+              >{{
+                t('demo.nanoTransactionResults.receiveConfirmationBlock')
+              }}&ensp;</strong
             >
             <a
               style="display: inline-block"
               :href="`https://nanocrawler.cc/explorer/block/${confirmationReceiveHash}`"
               target="_blank"
-              >on NanoCrawler</a
+              >{{ t('demo.nanoTransactionResults.nanoCrawlerLink') }}</a
             >
           </div>
         </div>
@@ -59,6 +77,8 @@
 </template>
 
 <script>
+import { useI18n } from 'vue-i18n';
+
 export default {
   name: 'NanoTransactionResults',
   props: {
@@ -68,6 +88,10 @@ export default {
     transactionTime: String,
     confirmationSendHash: String,
     confirmationReceiveHash: String,
+  },
+  setup() {
+    const { t } = useI18n({ useScope: 'global' });
+    return { t };
   },
 };
 </script>

--- a/src/components/demo/NanoWallet.vue
+++ b/src/components/demo/NanoWallet.vue
@@ -7,7 +7,7 @@
       'wallet-other': $mq === 'other',
     }"
   >
-    <h3 class="wallet-label">Nano Wallet {{ walletLetter }}</h3>
+    <h3 class="wallet-label">{{ t('demo.nanoWallet.walletLabel', { walletLetter }) }}</h3>
     <img
       class="logo"
       :class="{
@@ -18,18 +18,25 @@
       src="../../assets/wallet.png"
     />
     <div style="display: block">
-      <strong style="display: inline-block">Address:&ensp;</strong>
+      <strong style="display: inline-block"
+        >{{ t('demo.nanoWallet.addressLabel') }}&ensp;</strong
+      >
       <div class="overflow" style="display: inline-block">{{ shortenedNanoAddress }}</div>
     </div>
     <div style="display: block">
-      <strong style="display: inline-block">Balance:&ensp;</strong>
-      <div class="overflow" style="display: inline-block">{{ nanoBalance }} Ñ</div>
+      <strong style="display: inline-block"
+        >{{ t('demo.nanoWallet.walletBalance.label') }}&ensp;</strong
+      >
+      <div class="overflow" style="display: inline-block">
+        {{ t('demo.nanoWallet.walletBalance.amount', { nanoBalance }) }}
+      </div>
     </div>
   </div>
 </template>
 
 <script>
 import { computed } from 'vue';
+import { useI18n } from 'vue-i18n';
 import removeTrailingZeros from 'remove-trailing-zeros';
 import { tools } from 'nanocurrency-web';
 
@@ -41,13 +48,14 @@ export default {
     walletBalance: Object,
   },
   setup(props) {
+    const { t } = useI18n({ useScope: 'global' });
     const shortenedNanoAddress = computed(
       () => props.walletAddress.slice(0, 5) + props.walletAddress.slice(-7)
     );
     const nanoBalance = computed(() => {
       return removeTrailingZeros(tools.convert(props.walletBalance.raw, 'RAW', 'NANO'));
     });
-    return { shortenedNanoAddress, nanoBalance };
+    return { t, shortenedNanoAddress, nanoBalance };
   },
 };
 </script>

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -165,6 +165,36 @@
     }
   },
   "feedbackForm": {
-    "language": "Languages"
+    "title": "Give Feedback",
+    "name": {
+      "label": "Name",
+      "rule": "Please enter a name"
+    },
+    "email": {
+      "label": "Email",
+      "rules": {
+        "required": "Please enter an email",
+        "email": "Invalid email address"
+      }
+    },
+    "feedbackType": {
+      "label": "Feedback Type",
+      "type": {
+        "bug": "Bug",
+        "featureRequest": "Feature Request",
+        "other": "Other"
+      }
+    },
+    "message": {
+      "label": "Email",
+      "rules": {
+        "required": "Please enter a message",
+        "min": "Please enter more than 10 characters"
+      }
+    },
+    "buttons": {
+      "cancel": "Cancel",
+      "confirm": "Confirm"
+    }
   }
 }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -81,13 +81,18 @@
         "time": "{time} seconds"
       }
     },
-    "nanoTransactionResults": {
-      "language": "Languages"
+    "nanoWallet": {
+      "walletLabel": "Nano Wallet {walletLetter}",
+      "addressLabel": "Address:",
+      "walletBalance": {
+        "label": "Balance:",
+        "amount": "{nanoBalance} Ñ"
+      }
     },
     "nanoTransactionStatusBar": {
       "language": "Languages"
     },
-    "nanoWallet": {
+    "nanoTransactionResults": {
       "language": "Languages"
     }
   },

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1,0 +1,126 @@
+{
+  "nanoApp": {
+    "networkAlert": "TryNano is currently facing difficulties while trying to communicate with the Nano network. Thank you for your understanding!",
+    "steps": {
+      "title": "Step {count}",
+      "description": {
+        "one": "Grab Some Nano",
+        "two": "Try It Out",
+        "three": "Set Up Your Wallet",
+        "four": "Done!"
+      }
+    },
+    "steppers": {
+      "previous": " Previous Step",
+      "next": "Next Step "
+    },
+    "generatingWallets": "Generating Wallets..."
+  },
+  "nanoIntro": {
+    "firstSentence": "TryNano demonstrates how fast and simple Nano transactions are by giving you two wallets to send Nano back and forth between each other.",
+    "secondSentence": {
+      "main": "{0} Nano (NANO) is a peer-to-peer digital currency designed to provide instant transactions, zero fees, and scalability, all while being eco-friendly.",
+      "whatIsNano": "What is Nano?"
+    },
+    "revealText": "Click here to try it out yourself!"
+  },
+  "nanoFaucetInfo": {
+    "faucetButton": "Use the TryNano Faucet",
+    "requestingFaucet": "Requesting Nano from Faucet...",
+    "receivePendingFromFaucet": "Faucet Nano sent! Receiving pending Nano from Faucet...",
+    "faucetReceived": "Faucet Nano Received!",
+    "gettingFaucetInfo": "Getting Faucet Info...",
+    "faucetBalance": {
+      "main": "Faucet balance: {0}",
+      "balance": "{faucetBalance} Ñ"
+    },
+    "faucetPayout": {
+      "main": "Faucet payout: {0}",
+      "payout": "{faucetPayout}"
+    },
+    "dividerText": "OR",
+    "firstSentence": {
+      "main": "Go to {0} and paste the generated wallet address below.",
+      "faucetUrl": "nano-faucet.org"
+    },
+    "secondSentence": {
+      "main": "({0}: If you've received a tip from someone using NanoTipBot and would like to use that instead, use the !withdraw command outlined {1}.)",
+      "note": "Note",
+      "nanoTipBotUrl": "here"
+    },
+    "popover": {
+      "main": "A {0} is a unique identifier that serves as a virtual location where cryptocurrency can be sent/received, similar to having an email address!",
+      "walletAddress": "wallet address"
+    },
+    "tooltip": {
+      "copyAddress": "Copy Address",
+      "copiedAddress": "Copied!"
+    },
+    "generatedWalletAddress": "Generated wallet address",
+    "depositStatus": {
+      "main": "Status:",
+      "notReceived": "Not Received",
+      "received": "Received!"
+    },
+    "walletBalance": {
+      "main": "Balance:",
+      "amount": "{walletBalance} Ñ"
+    }
+  },
+  "demo": {
+    "nanoDemo": {
+      "firstSentence": "Try sending some nano back and forth between these two wallets to get a feel for just how quick and easy it is to use Nano!",
+      "firstWalletLetter": "A",
+      "secondWalletLetter": "B",
+      "sendToWallet": "Send to Wallet {walletLetter}",
+      "sending": "Sending...",
+      "sent": "Sent!",
+      "confirmingReceivedNano": "Confirming Received Nano...",
+      "transactionTime": {
+        "default": "N/A",
+        "time": "{time} seconds"
+      }
+    },
+    "nanoTransactionResults": {
+      "language": "Languages"
+    },
+    "nanoTransactionStatusBar": {
+      "language": "Languages"
+    },
+    "nanoWallet": {
+      "language": "Languages"
+    }
+  },
+  "claimNano": {
+    "firstSentence": {
+      "main": "To claim back your Nano, you'll need to set up a {0} to store it in.",
+      "privateWallet": "private wallet"
+    },
+    "secondSentence": {
+      "main": "The most popular wallets in the Nano community are {0} (Android/iOS) and {1} (Web/Desktop).",
+      "natrium": "Natrium",
+      "nault": "Nault"
+    },
+    "thirdSentence": {
+      "main": "(For a more complete list of options, please visit {0}.)",
+      "guide": "this guide"
+    },
+    "fourthSentence": "Once you've finished setting up your wallet, enter your new Nano wallet address below and click send. That's it!",
+    "addressPlaceholder": "Enter your Nano address...",
+    "validNanoAddress": "Valid Nano Address",
+    "invalidNanoAddress": "Invalid Nano Address",
+    "send": "Send",
+    "returnToSender": "Return Back to Sender",
+    "sending": "Sending..",
+    "sent": "Sent!"
+  },
+  "nanoResources": {
+    "language": "Languages"
+  },
+  "nanoFooter": {
+    "language": "Languages"
+  },
+  "feedbackForm": {
+    "language": "Languages"
+  }
+}

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -133,7 +133,14 @@
     "sent": "Sent!"
   },
   "nanoResources": {
-    "language": "Languages"
+    "title": "Thanks for using TryNano!",
+    "firstSentence": {
+      "main": "For a comprehensive list of resources related to Nano including the core team, social media channels, where to buy Nano, and more, please visit {0}.",
+      "nanoLinksUrl": "nanolinks.info"
+    },
+    "secondSentence": {
+      "main": "If you liked this experience, please consider donating to me at {0} or the TryNano Faucet {1} to help keep the website up and running!"
+    }
   },
   "nanoFooter": {
     "language": "Languages"

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -89,11 +89,24 @@
         "amount": "{nanoBalance} Ñ"
       }
     },
-    "nanoTransactionStatusBar": {
-      "language": "Languages"
-    },
     "nanoTransactionResults": {
-      "language": "Languages"
+      "title": "Transaction Results",
+      "placeholder": "Send Nano between the two wallets to start a transaction!",
+      "transactionTime": {
+        "label": "Transaction Time:",
+        "time": "{transactionTime}"
+      },
+      "transactionFees": {
+        "label": "Transaction Fees:",
+        "fees": "None"
+      },
+      "energyConsumption": {
+        "label": "Energy Consumption:",
+        "usage": "~ 0.000112 kWh"
+      },
+      "sendConfirmationBlock": "Link to sent confirmation block",
+      "receiveConfirmationBlock": "Link to received confirmation block",
+      "nanoCrawlerLink": "on NanoCrawler"
     }
   },
   "claimNano": {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -143,7 +143,26 @@
     }
   },
   "nanoFooter": {
-    "language": "Languages"
+    "createdBy": {
+      "main": "Created by {0} and {1}.",
+      "omar": "Omar Baradei",
+      "patrick": "Patrick Smith"
+    },
+    "github": {
+      "main": "Link to {0}.",
+      "url": "GitHub"
+    },
+    "faucet": "Donate to the TryNano Faucet: {0}.",
+    "tips": "Tips accepted at: {0}.",
+    "feedback": {
+      "main": "Give feedback {0}.",
+      "feedbackLink": "here"
+    },
+    "recaptcha": {
+      "main": " This site is protected by reCAPTCHA and the {0} and the {1} apply.",
+      "policy": "Google Privacy Policy",
+      "tos": "Terms of Service"
+    }
   },
   "feedbackForm": {
     "language": "Languages"

--- a/src/locales/pt-br.json
+++ b/src/locales/pt-br.json
@@ -1,0 +1,200 @@
+{
+  "nanoApp": {
+    "networkAlert": "No momento o TryNano está com dificuldades para se comunicar com a rede da Nano. Obrigado pela sua compreensão",
+    "steps": {
+      "title": "Passo {count}",
+      "description": {
+        "one": "Pegue algumas Nanos",
+        "two": "Experimente",
+        "three": "Crie sua Carteira",
+        "four": "Pronto!"
+      }
+    },
+    "steppers": {
+      "previous": "Passo Anterior",
+      "next": "Próximo Passo"
+    },
+    "generatingWallets": "Criando carteiras ..."
+  },
+  "nanoIntro": {
+    "firstSentence": "O TryNano mostra quão rápido e simples é fazer uma transação com Nano dando a você 2 carteiras para enviar Nano de uma para outra",
+    "secondSentence": {
+      "main": "{0} Nano (NANO) é uma moeda digital projetada para ter transações instantâneas, zero taxas e escalabilidade. Tudo isso sendo eco-friendly",
+      "whatIsNano": "O que é a Nano?"
+    },
+    "revealText": "Clique aqui para testar você mesmo!"
+  },
+  "nanoFaucetInfo": {
+    "faucetButton": "Use nosso faucet",
+    "requestingFaucet": "Requisitando Nano do faucet ...",
+    "receivePendingFromFaucet": "Nano enviada! Recebendo Nanos pendentes dos Faucet...",
+    "faucetReceived": "Nanos recebidas do Faucet!",
+    "gettingFaucetInfo": "Carregando informação do Faucet...",
+    "faucetBalance": {
+      "main": "Saldo do Faucet: {0}",
+      "balance": "{faucetBalance} Ñ"
+    },
+    "faucetPayout": {
+      "main": "Pagamento do Faucet: {0}",
+      "payout": "{faucetPayout}"
+    },
+    "dividerText": "OU",
+    "firstSentence": {
+      "main": "Vá para {0} e cole o endereço da carteira gerado abaixo.",
+      "faucetUrl": "nano-faucet.org"
+    },
+    "secondSentence": {
+      "main": "({0}: ISe você recebeu um tip de alguém usando o NanoTipBot e gostaria de usar essas Nanos, use o comando !withdraw {1}.)",
+      "note": "Nota",
+      "nanoTipBotUrl": "aqui"
+    },
+    "popover": {
+      "main": "Um {0} é um identificador único que serve como um local virtual onde é possivel enviar e receber Nanos, similar a um endereço de email!",
+      "walletAddress": "endereço de carteira"
+    },
+    "tooltip": {
+      "copyAddress": "Copiar endereço",
+      "copiedAddress": "Copiado!"
+    },
+    "generatedWalletAddress": "Endereço de carteira gerado",
+    "depositStatus": {
+      "main": "Status:",
+      "notReceived": "Não recebido",
+      "received": "Recebido!"
+    },
+    "walletBalance": {
+      "main": "Saldo:",
+      "amount": "{walletBalance} Ñ"
+    }
+  },
+  "demo": {
+    "nanoDemo": {
+      "firstSentence": "Tente enviar nano de uma carteira para outra para ver como é fácil e rápido usar Nano!",
+      "firstWalletLetter": "A",
+      "secondWalletLetter": "B",
+      "sendToWallet": "Enviao para a carteira {walletLetter}",
+      "sending": "Enviando...",
+      "sent": "Enviado!",
+      "confirmingReceivedNano": "Confirmando o recebimento das Nanos...",
+      "transactionTime": {
+        "default": "N/A",
+        "time": "{time} segundos"
+      }
+    },
+    "nanoWallet": {
+      "walletLabel": "Carteira Nano {walletLetter}",
+      "addressLabel": "Endereço:",
+      "walletBalance": {
+        "label": "Saldo:",
+        "amount": "{nanoBalance} Ñ"
+      }
+    },
+    "nanoTransactionResults": {
+      "title": "Resultados da transação",
+      "placeholder": "Envie Nano entre duas carteiras para fazer uma transferência!",
+      "transactionTime": {
+        "label": "Tempo da transação:",
+        "time": "{transactionTime}"
+      },
+      "transactionFees": {
+        "label": "Taxas:",
+        "fees": "Zero"
+      },
+      "energyConsumption": {
+        "label": "Consumo de energia:",
+        "usage": "~ 0.000112 kWh"
+      },
+      "sendConfirmationBlock": "Link do bloco de confirmação",
+      "receiveConfirmationBlock": "Link do bloco de recebimento",
+      "nanoCrawlerLink": "no NanoCrawler"
+    }
+  },
+  "claimNano": {
+    "firstSentence": {
+      "main": "Para pegar suas Nanos de volta, você vai precisar criar uma {0} para guardar suas Nanos.",
+      "privateWallet": "carteira própria"
+    },
+    "secondSentence": {
+      "main": "As carteiras mas populares da comunidade Nano são a {0} (Android/iOS) e a {1} (Web/Desktop).",
+      "natrium": "Natrium",
+      "nault": "Nault"
+    },
+    "thirdSentence": {
+      "main": "(Para uma lista mais completade opções, por favor visite {0}.)",
+      "guide": "este guia"
+    },
+    "fourthSentence": "Assim que você tiver cabado de criar sua carteira, insira seu endereço Nano da carteira abaixo em clique em enviar. Simples, assim!",
+    "addressPlaceholder": "Insira se endereço Nano...",
+    "validNanoAddress": "Endereço Nano válido",
+    "invalidNanoAddress": "Endereço Nano inválido",
+    "send": "Enviar",
+    "returnToSender": "Envie de volta",
+    "sending": "Enviando..",
+    "sent": "Enviado!"
+  },
+  "nanoResources": {
+    "title": "Obrigado por usar o TryNano!",
+    "firstSentence": {
+      "main": " Para uma lista compreensiva de recursos relacionados à Nano incluindo a equipe de desenvolvimento, canais de media social, onde comprar Nano e mais. Por favor visite {0}.",
+      "nanoLinksUrl": "nanolinks.info"
+    },
+    "secondSentence": {
+      "main": "Se você gostou da experiência, considera fazer uma doação para mim {0} ou para o faucet do TryNano  {1} para ajusdar o site a continuar rodando!"
+    }
+  },
+  "nanoFooter": {
+    "createdBy": {
+      "main": "Criado por {0} and {1}.",
+      "omar": "Omar Baradei",
+      "patrick": "Patrick Smith"
+    },
+    "github": {
+      "main": "Link para {0}.",
+      "url": "GitHub"
+    },
+    "faucet": "Doe para o faucet do TryNano: {0}.",
+    "tips": "Tips aceitas em: {0}.",
+    "feedback": {
+      "main": "Deixe um feedback {0}.",
+      "feedbackLink": "aqui"
+    },
+    "recaptcha": {
+      "main": " Esse site é protegido pelo reCAPTCHA e a {0} e {1} se aplicam.",
+      "policy": "Politica de privacidade do Google",
+      "tos": "Termos de Serviço"
+    }
+  },
+  "feedbackForm": {
+    "title": "Deixe um feedback",
+    "name": {
+      "label": "Nome",
+      "rule": "Por favor, insira um nome"
+    },
+    "email": {
+      "label": "Email",
+      "rules": {
+        "required": "Por favor, insira um email",
+        "email": "Email inválido"
+      }
+    },
+    "feedbackType": {
+      "label": "Typo do feedback",
+      "type": {
+        "bug": "Bug",
+        "featureRequest": "Feature Request",
+        "other": "Other"
+      }
+    },
+    "message": {
+      "label": "Email",
+      "rules": {
+        "required": "Por favor, insira uma mensagem",
+        "min": "Por favor, insira mais de 10 caracteres"
+      }
+    },
+    "buttons": {
+      "cancel": "Cancelar",
+      "confirm": "Confirmar"
+    }
+  }
+}

--- a/src/main.js
+++ b/src/main.js
@@ -21,6 +21,7 @@ app.config.globalProperties.emitter = emitter;
 const vueMqConfig = {
   breakpoints: {
     phone: 450,
+    tabletSm: 750,
     tablet: 1250,
     other: Infinity,
   },

--- a/src/main.js
+++ b/src/main.js
@@ -5,9 +5,11 @@ import { VueReCaptcha } from "vue-recaptcha-v3";
 import VueMq from "vue3-mq";
 import axios from "axios";
 import VueAxios from "vue-axios";
+import { createI18n } from 'vue-i18n'
 import NanoApp from "./NanoApp.vue";
 import installElementPlus from "./plugins/element";
 import "../node_modules/hover.css";
+import translations from "./translations";
 
 const app = createApp(NanoApp);
 installElementPlus(app);
@@ -28,6 +30,16 @@ const vueMqConfig = {
 axios.defaults.baseURL = process.env.VUE_APP_SERVER_URL;
 axios.defaults.headers.common['Content-Type'] = 'application/json';
 
+// 2. Create i18n instance with options
+const i18n = createI18n({
+  legacy: false, // you must set `false`, to use Compostion API
+  locale: 'en', // set locale
+  fallbackLocale: 'en', // set fallback locale
+  messages: translations, // set locale messages
+  // If you need to specify other options, you can set other options
+  // ...
+})
+
 // silence all Vue warns
 app.config.warnHandler = () => null;
 
@@ -36,4 +48,5 @@ app
   .use(VueClipboard)
   .use(VueMq, vueMqConfig)
   .use(VueReCaptcha, { siteKey: process.env.VUE_APP_RECAPTCHA_SITE_KEY })
+  .use(i18n)
   .mount("#app");

--- a/src/translations.js
+++ b/src/translations.js
@@ -1,0 +1,13 @@
+import en from './locales/en.json';
+
+/* To add a new translation: 
+    1. create a new json file under ./locals/<language>.json
+    2. Follow the same structure seen in the other translation files
+    3. import it inside this file
+    4. Add it to the list below
+*/
+const translations = {
+    en, /* english */
+}
+
+export default translations;

--- a/src/translations.js
+++ b/src/translations.js
@@ -1,4 +1,5 @@
 import en from './locales/en.json';
+import * as ptBr from './locales/pt-br.json';
 
 /* To add a new translation: 
     1. create a new json file under ./locals/<language>.json
@@ -7,7 +8,8 @@ import en from './locales/en.json';
     4. Add it to the list below
 */
 const translations = {
-    en, /* english */
+    en, /* English */
+    ptBr: ptBr.default, /* Brazilian Portuguese */
 }
 
 export default translations;

--- a/src/translations.js
+++ b/src/translations.js
@@ -9,7 +9,7 @@ import * as ptBr from './locales/pt-br.json';
 */
 const translations = {
     en, /* English */
-    ptBr: ptBr.default, /* Brazilian Portuguese */
+    'pt-BR': ptBr.default, /* Brazilian Portuguese */
 }
 
 export default translations;

--- a/yarn.lock
+++ b/yarn.lock
@@ -900,6 +900,44 @@
     "cssnano-preset-default" "^4.0.0"
     "postcss" "^7.0.0"
 
+"@intlify/core-base@9.0.0":
+  "integrity" "sha512-dxqakT94EV2bFshG3LENQUPWX9yJFCga1BOwJ6mz7J8LnAYVB9Kxw7NRyE2ybN31USW2IUTQH6WWR1yDbCiefQ=="
+  "resolved" "https://registry.npmjs.org/@intlify/core-base/-/core-base-9.0.0.tgz"
+  "version" "9.0.0"
+  dependencies:
+    "@intlify/message-compiler" "9.0.0"
+    "@intlify/message-resolver" "9.0.0"
+    "@intlify/runtime" "9.0.0"
+    "@intlify/shared" "9.0.0"
+
+"@intlify/message-compiler@9.0.0":
+  "integrity" "sha512-3oiLj+8z6koRYJwknazjilBsrqnJEAJywr/t39MYVy2yPmwOI1+NDfdDwM9U3ioA2RvsQEUICqW8gmjq1YIElw=="
+  "resolved" "https://registry.npmjs.org/@intlify/message-compiler/-/message-compiler-9.0.0.tgz"
+  "version" "9.0.0"
+  dependencies:
+    "@intlify/message-resolver" "9.0.0"
+    "@intlify/shared" "9.0.0"
+    "source-map" "0.6.1"
+
+"@intlify/message-resolver@9.0.0":
+  "integrity" "sha512-LVK4cwu1l33yvBy0UQkEdXm6pZUcbbiparobruJXz+U8jRTmYHBprN59j59YKXEKcV43cHfzNveaQIm84bgxvQ=="
+  "resolved" "https://registry.npmjs.org/@intlify/message-resolver/-/message-resolver-9.0.0.tgz"
+  "version" "9.0.0"
+
+"@intlify/runtime@9.0.0":
+  "integrity" "sha512-UqCKduZezb5/qA+XPRfHVvXoLmhnQ8iKMyCh0Lg3ZwjW2vOMep/AgZU3T9cgESe67r4buPYHs7nOBSHbTdjNxg=="
+  "resolved" "https://registry.npmjs.org/@intlify/runtime/-/runtime-9.0.0.tgz"
+  "version" "9.0.0"
+  dependencies:
+    "@intlify/message-compiler" "9.0.0"
+    "@intlify/message-resolver" "9.0.0"
+    "@intlify/shared" "9.0.0"
+
+"@intlify/shared@9.0.0":
+  "integrity" "sha512-0r4v7dnY8g/Jfx2swUWy2GyfH/WvIpWvkU4OIupvxDTWiE8RhcpbOCVvqpVh/xGi0proHQ/r2Dhc0QSItUsfDQ=="
+  "resolved" "https://registry.npmjs.org/@intlify/shared/-/shared-9.0.0.tgz"
+  "version" "9.0.0"
+
 "@mrmlnc/readdir-enhanced@^2.2.1":
   "integrity" "sha512-bPHp6Ji8b41szTOcaP63VlnbbO5Ny6dwAATtY6JTjh5N2OLrb5Qk/Th5cRkRQhkWCt+EJsYrNB0MiL+Gpn6e3g=="
   "resolved" "https://registry.npmjs.org/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz"
@@ -1441,6 +1479,11 @@
     "vue-template-es2015-compiler" "^1.9.0"
   optionalDependencies:
     "prettier" "^1.18.2"
+
+"@vue/devtools-api@^6.0.0-beta.5":
+  "integrity" "sha512-mIfqX8ZF6s2ulelIzfxGk9sFoigpoeK/2/DlWrtBGWfvwaK3kR1P2bxNkZ0LbJeuKHfcRP6hGZtGist7nxUN9A=="
+  "resolved" "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-6.0.0-beta.7.tgz"
+  "version" "6.0.0-beta.7"
 
 "@vue/eslint-config-airbnb@^5.0.2":
   "integrity" "sha512-m9ldRhbqaODbcc9mQZjPgnTzyNweZblLMTqMfC2kHWY68dYd3kwG/hvENeZWXJnKKo+eGnoptk+7Zq/c1519ZQ=="
@@ -8119,6 +8162,11 @@
   "resolved" "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz"
   "version" "0.6.1"
 
+"source-map@0.6.1":
+  "integrity" "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+  "resolved" "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz"
+  "version" "0.6.1"
+
 "sourcemap-codec@^1.4.4":
   "integrity" "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA=="
   "resolved" "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz"
@@ -9000,6 +9048,15 @@
   "integrity" "sha512-BXq3jwIagosjgNVae6tkHzzIk6a8MHFtzAdwhnV5VlvPTFxDCvIttgSiHWjdGoTJvXtmRu5HacExfdarRcFhog=="
   "resolved" "https://registry.npmjs.org/vue-hot-reload-api/-/vue-hot-reload-api-2.3.4.tgz"
   "version" "2.3.4"
+
+"vue-i18n@^9.0.0":
+  "integrity" "sha512-iks0eJDv/4cK/7tl/ooMUroNVVIGOK4kKS1PIHmPQk7QjT/sDfFM84vjPKgpARbw0GjJsOiADL43jufNfs9e9A=="
+  "resolved" "https://registry.npmjs.org/vue-i18n/-/vue-i18n-9.0.0.tgz"
+  "version" "9.0.0"
+  dependencies:
+    "@intlify/core-base" "9.0.0"
+    "@intlify/shared" "9.0.0"
+    "@vue/devtools-api" "^6.0.0-beta.5"
 
 "vue-loader-v16@npm:vue-loader@^16.1.0":
   "integrity" "sha512-8QTxh+Fd+HB6fiL52iEVLKqE9N1JSlMXLR92Ijm6g8PZrwIxckgpqjPDWRP5TWxdiPaHR+alUWsnu1ShQOwt+Q=="


### PR DESCRIPTION
Added i18n support. User is now able to select their language from the selector in the top right corner of the page. 

To add a new language, you will need to create a new json file inside the ```src/locales``` folder. The filename should be: ```<locale_abbreviation>.json```.

You will need to follow the same structure inside en.json, which holds all the English translations for the site. For details on how the syntax works, please refer to the [Vue-I18n documentation](https://vue-i18n.intlify.dev/guide/).

Once you've created the json file, you'll need to add it inside translations.js. See how "en.json" is imported + added as an example. 

Lastly, you'll need to add the language name mapping inside ```NanoApp.vue```:

![image](https://user-images.githubusercontent.com/21279036/111917325-95c02300-8a3c-11eb-89e0-e82b8d9647c5.png)

When adding your language name mapping here, It is encouraged to use the language name in its own language so users will be able to quickly identify it in the dropdown.

For any additional questions, please reach out to me and I can help out. Thanks!